### PR TITLE
feat: add XOR chain_id/chain_name parameter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ src/eas_sdk/proto/
 buf.lock
 
 CLAUDE.md
+node_modules/

--- a/examples/full_example.py
+++ b/examples/full_example.py
@@ -36,39 +36,41 @@ class EASWorkflowExample:
     def setup_eas(self) -> bool:
         """Set up EAS instance."""
         print("🔧 Setting up EAS instance...")
-        
+
         try:
             # Method 1: From environment (recommended)
             self.eas = EAS.from_environment()
             print("   ✅ EAS created from environment variables")
             return True
-            
+
         except Exception as env_error:
             print(f"   ⚠️  Environment setup failed: {env_error}")
-            
+
             # Method 2: Direct configuration (fallback)
             try:
                 print("   🔄 Trying direct configuration...")
-                
+
                 # Get configuration for testnet
                 config = get_network_config("sepolia")
-                
+
                 # You would need to provide these values
                 private_key = os.getenv("PRIVATE_KEY")
-                from_account = os.getenv("FROM_ACCOUNT") 
-                
+                from_account = os.getenv("FROM_ACCOUNT")
+
                 if not private_key or not from_account:
-                    print("   ❌ PRIVATE_KEY and FROM_ACCOUNT environment variables required")
+                    print(
+                        "   ❌ PRIVATE_KEY and FROM_ACCOUNT environment variables required"
+                    )
                     return False
-                
+
                 self.eas = EAS.from_chain(
                     chain_name="sepolia",
                     private_key=private_key,
-                    from_account=from_account
+                    from_account=from_account,
                 )
                 print("   ✅ EAS created with direct configuration")
                 return True
-                
+
             except Exception as direct_error:
                 print(f"   ❌ Direct configuration failed: {direct_error}")
                 return False
@@ -76,22 +78,22 @@ class EASWorkflowExample:
     def register_schema(self) -> bool:
         """Register a schema for our attestations."""
         print("\n📝 Registering schema...")
-        
+
         try:
             # Define a useful schema for user profiles
             schema = "string name,string email,uint256 reputation,bool verified,bytes32 profileHash"
-            
+
             print(f"   Schema: {schema}")
-            
+
             result = self.eas.register_schema(
                 schema=schema,
-                network_name="sepolia",  # Use testnet for safety
-                revocable=True  # Allow revocations
+                chain_name="sepolia",  # Use testnet for safety
+                revocable=True,  # Allow revocations
             )
-            
+
             if result.success:
                 # Extract schema UID from transaction logs or response
-                schema_uid = result.data.get('schema_uid')
+                schema_uid = result.data.get("schema_uid")
                 if schema_uid:
                     self.schema_uid = schema_uid
                     print(f"   ✅ Schema registered: {schema_uid}")
@@ -103,7 +105,7 @@ class EASWorkflowExample:
             else:
                 print(f"   ❌ Schema registration failed: {result.error}")
                 return False
-                
+
         except Exception as e:
             print(f"   ❌ Schema registration error: {e}")
             return False
@@ -111,43 +113,47 @@ class EASWorkflowExample:
     def create_attestation(self) -> bool:
         """Create an attestation using our schema."""
         print("\n🏅 Creating attestation...")
-        
+
         if not self.schema_uid:
             print("   ❌ No schema UID available")
             return False
-        
+
         try:
             # Prepare attestation data
-            recipient = "0x742d35Cc6634C0532925a3b8D16c30B9b2C4e40B"  # Example recipient
-            
+            recipient = (
+                "0x742d35Cc6634C0532925a3b8D16c30B9b2C4e40B"  # Example recipient
+            )
+
             # Encode data according to our schema
             # Schema: "string name,string email,uint256 reputation,bool verified,bytes32 profileHash"
             attestation_data = encode(
                 ["string", "string", "uint256", "bool", "bytes32"],
                 [
                     "Alice Johnson",
-                    "alice@example.com", 
+                    "alice@example.com",
                     1000,  # reputation score
                     True,  # verified
-                    bytes.fromhex("a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890")
-                ]
+                    bytes.fromhex(
+                        "a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890"
+                    ),
+                ],
             )
-            
+
             print(f"   👤 Recipient: {recipient}")
             print(f"   📦 Data length: {len(attestation_data)} bytes")
-            
+
             result = self.eas.create_attestation(
                 schema_uid=self.schema_uid,
                 recipient=recipient,
                 encoded_data=attestation_data,
                 expiration=0,  # No expiration
                 revocable=True,
-                value=0  # No ETH value
+                value=0,  # No ETH value
             )
-            
+
             if result.success:
                 # Extract attestation UID from transaction logs
-                attestation_uid = result.data.get('attestation_uid')
+                attestation_uid = result.data.get("attestation_uid")
                 if attestation_uid:
                     self.attestation_uid = attestation_uid
                     print(f"   ✅ Attestation created: {attestation_uid}")
@@ -160,7 +166,7 @@ class EASWorkflowExample:
             else:
                 print(f"   ❌ Attestation creation failed: {result.error}")
                 return False
-                
+
         except Exception as e:
             print(f"   ❌ Attestation creation error: {e}")
             return False
@@ -168,14 +174,14 @@ class EASWorkflowExample:
     def query_attestation(self) -> bool:
         """Query the attestation we just created."""
         print("\n🔍 Querying attestation...")
-        
+
         if not self.attestation_uid:
             print("   ⚠️  No attestation UID to query")
             return False
-            
+
         try:
             attestation = self.eas.get_attestation(self.attestation_uid)
-            
+
             if attestation:
                 print(f"   ✅ Attestation found:")
                 print(f"      Schema: {attestation[1]}")  # schema UID
@@ -192,7 +198,7 @@ class EASWorkflowExample:
             else:
                 print("   ❌ Attestation not found")
                 return False
-                
+
         except Exception as e:
             print(f"   ❌ Query error: {e}")
             return False
@@ -200,7 +206,7 @@ class EASWorkflowExample:
     def demonstrate_offchain_attestation(self) -> bool:
         """Demonstrate off-chain attestation."""
         print("\n🌐 Creating off-chain attestation...")
-        
+
         try:
             # Create off-chain attestation message
             message = {
@@ -211,23 +217,25 @@ class EASWorkflowExample:
                 "expirationTime": 0,
                 "revocable": True,
                 "refUID": None,
-                "data": json.dumps({
-                    "name": "Bob Smith",
-                    "email": "bob@example.com",
-                    "reputation": 750,
-                    "verified": False,
-                    "note": "Off-chain attestation example"
-                }).encode()
+                "data": json.dumps(
+                    {
+                        "name": "Bob Smith",
+                        "email": "bob@example.com",
+                        "reputation": 750,
+                        "verified": False,
+                        "note": "Off-chain attestation example",
+                    }
+                ).encode(),
             }
-            
+
             offchain_attestation = self.eas.attest_offchain(message)
-            
+
             print(f"   ✅ Off-chain attestation created")
             print(f"   🆔 UID: {offchain_attestation['message']['uid']}")
             print(f"   ✍️  Signature: {offchain_attestation['signature']['r'][:10]}...")
-            
+
             return True
-            
+
         except Exception as e:
             print(f"   ❌ Off-chain attestation error: {e}")
             return False
@@ -235,14 +243,14 @@ class EASWorkflowExample:
     def demonstrate_revocation(self) -> bool:
         """Demonstrate attestation revocation."""
         print("\n❌ Revoking attestation...")
-        
+
         if not self.attestation_uid:
             print("   ⚠️  No attestation UID to revoke")
             return False
-            
+
         try:
             result = self.eas.revoke_attestation(self.attestation_uid)
-            
+
             if result.success:
                 print(f"   ✅ Attestation revoked")
                 print(f"   🔗 Transaction: {result.tx_hash}")
@@ -250,7 +258,7 @@ class EASWorkflowExample:
             else:
                 print(f"   ❌ Revocation failed: {result.error}")
                 return False
-                
+
         except Exception as e:
             print(f"   ❌ Revocation error: {e}")
             return False
@@ -259,31 +267,33 @@ class EASWorkflowExample:
         """Run the complete EAS workflow."""
         print("🚀 EAS SDK Complete Workflow Example")
         print("=" * 50)
-        
+
         # Step 1: Setup
         if not self.setup_eas():
             print("\n❌ Setup failed. Cannot continue.")
             return
-        
+
         # Step 2: Register schema
         if not self.register_schema():
             print("\n⚠️  Using fallback schema for remaining examples...")
             # Use a known schema for testnets
-            self.schema_uid = "0x83c23d3c24c90bc5d1b8b44a7c2cc50e4d9efca2e80d78a3ce5f8e4d10e5d4e5"
-        
+            self.schema_uid = (
+                "0x83c23d3c24c90bc5d1b8b44a7c2cc50e4d9efca2e80d78a3ce5f8e4d10e5d4e5"
+            )
+
         # Step 3: Create attestation
         if self.create_attestation():
             # Step 4: Query attestation
             self.query_attestation()
-            
+
             # Step 5: Demonstrate revocation
             print("\n⏱️  Waiting 5 seconds before revocation...")
             time.sleep(5)
             self.demonstrate_revocation()
-        
+
         # Step 6: Off-chain attestation (always works)
         self.demonstrate_offchain_attestation()
-        
+
         print("\n✨ Complete workflow finished!")
         print("\n📚 What you've learned:")
         print("   • How to initialize EAS from environment variables")
@@ -291,7 +301,7 @@ class EASWorkflowExample:
         print("   • How to create and query attestations")
         print("   • How to create off-chain attestations")
         print("   • How to revoke attestations")
-        
+
         print("\n🛠️  Development Tips:")
         print("   • Use testnet (sepolia) for development")
         print("   • Check transaction status before proceeding")

--- a/examples/multi_chain_examples.py
+++ b/examples/multi_chain_examples.py
@@ -128,7 +128,7 @@ def demonstrate_factory_methods():
    from EAS.config import create_eas_instance
 
    eas = create_eas_instance(
-       network_name='mainnet',  # or 'sepolia', 'goerli', etc.
+       chain_name='mainnet',  # or 'sepolia', 'goerli', etc.
        from_account='0x1234...',
        private_key='0x1234...'
    )

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -31,10 +31,10 @@ from eas import EAS
 
 def main():
     """Quick start example showing common EAS operations."""
-    
+
     print("🚀 EAS SDK Quick Start Example")
     print("=" * 40)
-    
+
     # Example 1: Initialize EAS from environment
     print("\n1. Initialize EAS from environment variables")
     try:
@@ -51,11 +51,11 @@ def main():
     # Example 2: List supported chains
     print("\n2. List available chains")
     from eas.config import list_supported_chains, get_mainnet_chains, get_testnet_chains
-    
+
     all_chains = list_supported_chains()
     mainnet_chains = get_mainnet_chains()
     testnet_chains = get_testnet_chains()
-    
+
     print(f"   📊 Total supported chains: {len(all_chains)}")
     print(f"   🏦 Mainnet chains: {', '.join(mainnet_chains[:3])}...")
     print(f"   🧪 Testnet chains: {', '.join(testnet_chains[:3])}...")
@@ -65,15 +65,17 @@ def main():
     try:
         # Simple identity schema
         schema = "string name,uint256 age,bool verified"
-        result = eas.register_schema(schema, network_name="sepolia")  # Use testnet
-        
+        result = eas.register_schema(schema, chain_name="sepolia")  # Use testnet
+
         if result.success:
-            print(f"   ✅ Schema registered with UID: {result.data.get('schema_uid', 'N/A')}")
-            schema_uid = result.data.get('schema_uid')
+            print(
+                f"   ✅ Schema registered with UID: {result.data.get('schema_uid', 'N/A')}"
+            )
+            schema_uid = result.data.get("schema_uid")
         else:
             print(f"   ❌ Schema registration failed: {result.error}")
             schema_uid = None
-            
+
     except Exception as e:
         print(f"   ⚠️  Schema registration skipped: {e}")
         schema_uid = None
@@ -84,14 +86,16 @@ def main():
         # Use a known schema or the one we just created
         if not schema_uid:
             # Fallback to a common test schema (adjust as needed)
-            schema_uid = "0x83c23d3c24c90bc5d1b8b44a7c2cc50e4d9efca2e80d78a3ce5f8e4d10e5d4e5"
-        
+            schema_uid = (
+                "0x83c23d3c24c90bc5d1b8b44a7c2cc50e4d9efca2e80d78a3ce5f8e4d10e5d4e5"
+            )
+
         # Note: In a real application, you'd encode data properly
         # This is just for demonstration
         print(f"   📝 Using schema UID: {schema_uid}")
         print("   ⚠️  Attestation creation requires proper data encoding")
         print("   📚 See full_example.py for complete attestation workflow")
-        
+
     except Exception as e:
         print(f"   ⚠️  Attestation example skipped: {e}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eas-sdk"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for Ethereum Attestation Service (EAS)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/main/eas/exceptions.py
+++ b/src/main/eas/exceptions.py
@@ -164,7 +164,7 @@ class EASNetworkError(EASError):
         self,
         message: str,
         rpc_url: Optional[str] = None,
-        network_name: Optional[str] = None,
+        chain_name: Optional[str] = None,
     ):
         context = {}
         if rpc_url:
@@ -174,8 +174,8 @@ class EASNetworkError(EASError):
             context["rpc_url"] = SecureEnvironmentValidator.sanitize_for_logging(
                 rpc_url, "url"
             )
-        if network_name:
-            context["network_name"] = network_name
+        if chain_name:
+            context["chain_name"] = chain_name
         super().__init__(message, context)
 
 

--- a/src/main/eas/schema_registry.py
+++ b/src/main/eas/schema_registry.py
@@ -240,9 +240,9 @@ class SchemaRegistry:
             )
 
     @classmethod
-    def get_registry_address(cls, network_name: str) -> str:
-        """Get the schema registry contract address for a network."""
-        # Network-specific registry addresses
+    def get_registry_address(cls, chain_name: str) -> str:
+        """Get the schema registry contract address for a chain."""
+        # Chain-specific registry addresses
         # Note: These would need to be updated with actual EAS Schema Registry addresses
         registry_addresses = {
             "mainnet": "0x0a7E2Ff54e76B8E6659aedc9103FB21c038050D0",
@@ -251,11 +251,11 @@ class SchemaRegistry:
             "base-sepolia": "0x4200000000000000000000000000000000000020",  # Example - needs actual address
         }
 
-        if network_name not in registry_addresses:
+        if chain_name not in registry_addresses:
             raise EASValidationError(
-                f"Unsupported network for schema registry: {network_name}",
-                field_name="network_name",
-                field_value=network_name,
+                f"Unsupported chain for schema registry: {chain_name}",
+                field_name="chain_name",
+                field_value=chain_name,
             )
 
-        return registry_addresses[network_name]
+        return registry_addresses[chain_name]

--- a/src/main/eas/types.py
+++ b/src/main/eas/types.py
@@ -133,7 +133,7 @@ class ChainConfig(TypedDict):
     chain_id: Required[ChainId]
     rpc_url: Required[RpcUrl]
     contract_version: Required[ContractVersion]
-    network_name: NotRequired[str]
+    chain_name: NotRequired[str]
 
 
 class EIP712Domain(TypedDict):

--- a/src/test/test_security_validation.py
+++ b/src/test/test_security_validation.py
@@ -487,20 +487,34 @@ class TestSecurityIntegration:
             ),
         ):
 
-            eas = EAS.from_chain("ethereum", valid_key, valid_address)
+            eas = EAS.from_chain(
+                chain_name="ethereum", private_key=valid_key, from_account=valid_address
+            )
             assert eas is not None
 
         # Invalid chain name should fail
         with pytest.raises(ValueError, match="Security validation failed"):
-            EAS.from_chain("ethereum; rm -rf /", valid_key, valid_address)
+            EAS.from_chain(
+                chain_name="ethereum; rm -rf /",
+                private_key=valid_key,
+                from_account=valid_address,
+            )
 
         # Invalid private key should fail
         with pytest.raises(ValueError, match="Security validation failed"):
-            EAS.from_chain("ethereum", "invalid-key", valid_address)
+            EAS.from_chain(
+                chain_name="ethereum",
+                private_key="invalid-key",
+                from_account=valid_address,
+            )
 
         # Invalid address should fail
         with pytest.raises(ValueError, match="Security validation failed"):
-            EAS.from_chain("ethereum", valid_key, "invalid-address")
+            EAS.from_chain(
+                chain_name="ethereum",
+                private_key=valid_key,
+                from_account="invalid-address",
+            )
 
     @patch.dict(
         os.environ,
@@ -551,7 +565,7 @@ class TestSecurityIntegration:
         os.environ,
         {
             "EAS_CHAIN": "ethereum; rm -rf /",  # Injection attempt
-            "EAS_PRIVATE_KEY": "0x1234567890123456789012345678901234567890123456789012345678901234",
+            "EAS_PRIVATE_KEY": "0xa7c5ba7114b7119bb78dfc8e8ccd9f4ad8c6c9f2e8d7ab234fac8b1d5c7e9f12",
             "EAS_FROM_ACCOUNT": "0x1234567890123456789012345678901234567890",
         },
     )
@@ -559,7 +573,9 @@ class TestSecurityIntegration:
         """Test that environment variable injection is prevented"""
         from eas import EAS
 
-        with pytest.raises(ValueError, match="dangerous patterns"):
+        with pytest.raises(
+            ValueError, match="(dangerous patterns|Invalid chain name format)"
+        ):
             EAS.from_environment()
 
 

--- a/src/test/test_write_operations.py
+++ b/src/test/test_write_operations.py
@@ -79,7 +79,7 @@ class TestSchemaRegistry:
         assert len(address) == 42
 
         # Test unknown network
-        with pytest.raises(EASValidationError, match="Unsupported network"):
+        with pytest.raises(EASValidationError, match="Unsupported chain"):
             SchemaRegistry.get_registry_address("unknown-network")
 
 
@@ -277,7 +277,7 @@ class TestLiveWriteOperations:
         try:
             result = eas.register_schema(
                 schema=test_schema,
-                network_name="base-sepolia",
+                chain_name="base-sepolia",
                 resolver=None,
                 revocable=True,
             )


### PR DESCRIPTION
## Summary
- Add XOR parameter support for `chain_name` OR `chain_id` across `get_network_config()` and `EAS.from_chain()`
- Replace `network_name` with `chain_name` consistently throughout codebase
- Update CLI to support both `--chain-name` and `--chain-id` options
- Add helper functions for chain ID/name conversion

## Breaking Changes
- `get_network_config()` now requires keyword arguments and accepts XOR `chain_name`/`chain_id`
- `EAS.from_chain()` updated to use keyword-only arguments with XOR validation
- CLI `--network` option replaced with `--chain-name` and `--chain-id`
- All `network_name` parameters renamed to `chain_name`

## Test Plan
- [x] All existing tests updated and passing (115 passed, 13 skipped)
- [x] Type checking passes with MyPy
- [x] Linting passes with Flake8
- [x] Code formatting verified with Black
- [x] XOR validation tested for both API methods
- [x] CLI functionality verified for both parameter types