### PR TITLE
fix(ci): exclude generated protobuf files from black formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ extend-exclude = '''
   | build
   | dist
 )/
+|
+  # generated protobuf files
+  _pb2(_grpc)?\.pyi?$
 '''
 
 [tool.isort]


### PR DESCRIPTION
Generated `*_pb2.py` and `*_pb2_grpc.py` files were failing the black formatting check. These are auto-generated by protoc and shouldn't be reformatted.

This adds a pattern to `extend-exclude` in `pyproject.toml` to skip them.